### PR TITLE
namespace changed to support apache pio version 0.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,10 @@ assemblySettings
 
 name := "template-scala-parallel-complementarypurchase"
 
-organization := "io.prediction"
+organization := "org.apache.predictionio"
 
 libraryDependencies ++= Seq(
-  "io.prediction"    %% "core"          % pioVersion.value % "provided",
+  "org.apache.predictionio"    %% "apache-predictionio-core"          % pioVersion.value % "provided",
   "org.apache.spark" %% "spark-core"    % "1.3.0" % "provided",
   "org.apache.spark" %% "spark-mllib"   % "1.3.0" % "provided")
+

--- a/src/main/scala/Algorithm.scala
+++ b/src/main/scala/Algorithm.scala
@@ -1,7 +1,7 @@
 package org.template.complementarypurchase
 
-import io.prediction.controller.P2LAlgorithm
-import io.prediction.controller.Params
+import org.apache.predictionio.controller.P2LAlgorithm
+import org.apache.predictionio.controller.Params
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/DataSource.scala
+++ b/src/main/scala/DataSource.scala
@@ -1,11 +1,11 @@
 package org.template.complementarypurchase
 
-import io.prediction.controller.PDataSource
-import io.prediction.controller.EmptyEvaluationInfo
-import io.prediction.controller.EmptyActualResult
-import io.prediction.controller.Params
-import io.prediction.data.storage.Event
-import io.prediction.data.store.PEventStore
+import org.apache.predictionio.controller.PDataSource
+import org.apache.predictionio.controller.EmptyEvaluationInfo
+import org.apache.predictionio.controller.EmptyActualResult
+import org.apache.predictionio.controller.Params
+import org.apache.predictionio.data.storage.Event
+import org.apache.predictionio.data.store.PEventStore
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -1,7 +1,7 @@
 package org.template.complementarypurchase
 
-import io.prediction.controller.IEngineFactory
-import io.prediction.controller.Engine
+import org.apache.predictionio.controller.IEngineFactory
+import org.apache.predictionio.controller.Engine
 
 case class Query(items: Set[String], num: Int)
   extends Serializable

--- a/src/main/scala/Preparator.scala
+++ b/src/main/scala/Preparator.scala
@@ -1,6 +1,6 @@
 package org.template.complementarypurchase
 
-import io.prediction.controller.PPreparator
+import org.apache.predictionio.controller.PPreparator
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/Serving.scala
+++ b/src/main/scala/Serving.scala
@@ -1,6 +1,6 @@
 package org.template.complementarypurchase
 
-import io.prediction.controller.LServing
+import org.apache.predictionio.controller.LServing
 
 import grizzled.slf4j.Logger
 


### PR DESCRIPTION
the current template doesn't support the apache prediction io version 0.10.0, so I've changed the namespace and build.sbt for the template to work with pio version 0.10.0 . This has been tested and works when we have to build and use this template with pio version 0.10.0